### PR TITLE
Shrink the line width of logging spew

### DIFF
--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -133,7 +133,9 @@ export class CurrencyEngine {
 
     this.fees = { ...engineInfo.simpleFeeSettings, timestamp: 0 }
     console.log(
-      `${this.walletId.slice(0, 6)}: create engine type: ${this.walletInfo.type}`
+      `${this.walletId.slice(0, 6)}: create engine type: ${
+        this.walletInfo.type
+      }`
     )
   }
 

--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -92,6 +92,7 @@ export type CurrencyEngineSettings = {
 export class CurrencyEngine {
   walletInfo: EdgeWalletInfo
   walletId: string
+  prunedWalletId: string
   engineInfo: EngineCurrencyInfo
   currencyCode: string
   network: string
@@ -121,6 +122,7 @@ export class CurrencyEngine {
     const test: EdgeCurrencyEngine = this
     this.walletInfo = walletInfo
     this.walletId = walletInfo.id || ''
+    this.prunedWalletId = this.walletId.slice(0, 6)
     this.pluginState = pluginState
     this.callbacks = options.callbacks
     this.walletLocalFolder = options.walletLocalFolder
@@ -133,9 +135,7 @@ export class CurrencyEngine {
 
     this.fees = { ...engineInfo.simpleFeeSettings, timestamp: 0 }
     console.log(
-      `${this.walletId.slice(0, 6)}: create engine type: ${
-        this.walletInfo.type
-      }`
+      `${this.prunedWalletId}: create engine type: ${this.walletInfo.type}`
     )
   }
 
@@ -156,7 +156,7 @@ export class CurrencyEngine {
       localFolder: this.walletLocalFolder,
       encryptedLocalFolder: this.walletLocalEncryptedFolder,
       pluginState: this.pluginState,
-      walletId: this.walletId
+      walletId: this.prunedWalletId
     })
 
     await this.engineState.load()
@@ -272,7 +272,7 @@ export class CurrencyEngine {
         }
       }
     } catch (err) {
-      console.log(`${this.walletId.slice(0, 6)} - ${err.toString()}`)
+      console.log(`${this.prunedWalletId} - ${err.toString()}`)
     }
   }
 
@@ -295,7 +295,7 @@ export class CurrencyEngine {
     } catch (e) {
       console.log(
         `${
-          this.walletId
+          this.prunedWalletId
         } - Error while trying to update fee table ${e.toString()}`
       )
     }
@@ -347,7 +347,7 @@ export class CurrencyEngine {
       log += JSON.stringify(jsonObj, null, 2) + '\n'
     }
     log += '------------------------------------------------------------------'
-    console.log(`${this.walletId.slice(0, 6)}: ${log}`)
+    console.log(`${this.prunedWalletId}: ${log}`)
   }
   // ------------------------------------------------------------------------
   // Public API
@@ -437,7 +437,7 @@ export class CurrencyEngine {
         this.engineState.markAddressesUsed(scriptHashs)
         if (this.keyManager) this.keyManager.setLookAhead()
       })
-      .catch(e => console.log(`${this.walletId.slice(0, 6)}: ${e.toString()}`))
+      .catch(e => console.log(`${this.prunedWalletId}: ${e.toString()}`))
   }
 
   isAddressUsed (address: string, options: any): boolean {
@@ -492,7 +492,7 @@ export class CurrencyEngine {
       localFolder: this.walletLocalFolder,
       encryptedLocalFolder: this.walletLocalEncryptedFolder,
       pluginState: this.pluginState,
-      walletId: this.walletId
+      walletId: this.prunedWalletId
     })
 
     await engineState.load()
@@ -516,7 +516,7 @@ export class CurrencyEngine {
         this.io.fetch
       )
     } catch (err) {
-      console.log(`${this.walletId} - ${err.toString()}`)
+      console.log(`${this.prunedWalletId} - ${err.toString()}`)
       throw err
     }
   }

--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -132,6 +132,9 @@ export class CurrencyEngine {
     this.network = this.engineInfo.network
 
     this.fees = { ...engineInfo.simpleFeeSettings, timestamp: 0 }
+    console.log(
+      `${this.walletId.slice(0, 6)}: create engine type: ${this.walletInfo.type}`
+    )
   }
 
   async load (): Promise<any> {
@@ -267,7 +270,7 @@ export class CurrencyEngine {
         }
       }
     } catch (err) {
-      console.log(`${this.walletId} - ${err.toString()}`)
+      console.log(`${this.walletId.slice(0, 6)} - ${err.toString()}`)
     }
   }
 
@@ -342,7 +345,7 @@ export class CurrencyEngine {
       log += JSON.stringify(jsonObj, null, 2) + '\n'
     }
     log += '------------------------------------------------------------------'
-    console.log(`${this.walletId} - ${log}`)
+    console.log(`${this.walletId.slice(0, 6)}: ${log}`)
   }
   // ------------------------------------------------------------------------
   // Public API
@@ -432,7 +435,7 @@ export class CurrencyEngine {
         this.engineState.markAddressesUsed(scriptHashs)
         if (this.keyManager) this.keyManager.setLookAhead()
       })
-      .catch(e => console.log(`${this.walletId} - ${e.toString()}`))
+      .catch(e => console.log(`${this.walletId.slice(0, 6)}: ${e.toString()}`))
   }
 
   isAddressUsed (address: string, options: any): boolean {

--- a/src/engine/engineState.js
+++ b/src/engine/engineState.js
@@ -233,9 +233,9 @@ export class EngineState extends EventEmitter {
     try {
       const json = JSON.stringify({ keys: keys })
       await this.encryptedLocalFolder.file('keys.json').setText(json)
-      console.log(`${this.walletId.slice(0, 6)}: Saved keys cache`)
+      console.log(`${this.walletId}: Saved keys cache`)
     } catch (e) {
-      console.log(`${this.walletId.slice(0, 6)}: ${e.toString()}`)
+      console.log(`${this.walletId}: ${e.toString()}`)
     }
   }
 
@@ -248,7 +248,7 @@ export class EngineState extends EventEmitter {
       // TODO: Validate JSON
       return keysCacheJson.keys
     } catch (e) {
-      console.log(`${this.walletId.slice(0, 6)}: ${e.toString()}`)
+      console.log(`${this.walletId}: ${e.toString()}`)
       return {}
     }
   }
@@ -270,9 +270,7 @@ export class EngineState extends EventEmitter {
       const task = broadcastTx(
         rawTx,
         (txid: string) => {
-          console.log(
-            `${this.walletId.slice(0, 6)}: broadcastTx success: ${txid}`
-          )
+          console.log(`${this.walletId}: broadcastTx success: ${txid}`)
           // We resolve if any server succeeds:
           if (!resolved) {
             resolved = true
@@ -283,9 +281,7 @@ export class EngineState extends EventEmitter {
           // We fail if every server failed:
           if (++bad === uris.length) {
             const msg = e ? `With error ${e.toString()}` : ''
-            console.log(
-              `${this.walletId.slice(0, 6)} broadcastTx fail: ${rawTx}\n${msg}}`
-            )
+            console.log(`${this.walletId} broadcastTx fail: ${rawTx}\n${msg}}`)
             reject(e)
           }
         }
@@ -524,10 +520,7 @@ export class EngineState extends EventEmitter {
       )
     }
     console.log(
-      `${this.walletId.slice(
-        0,
-        6
-      )}: refillServers: Top ${NEW_CONNECTIONS} servers:`,
+      `${this.walletId} : refillServers: Top ${NEW_CONNECTIONS} servers:`,
       this.serverList
     )
     let chanceToBePicked = 1.25
@@ -556,10 +549,7 @@ export class EngineState extends EventEmitter {
         this.reconnect()
         break
       }
-      const prefix = `${this.walletId.slice(0, 6)} ${uri.replace(
-        'electrum://',
-        ''
-      )}:`
+      const prefix = `${this.walletId} ${uri.replace('electrum://', '')}:`
       const callbacks: StratumCallbacks = {
         onOpen: () => {
           this.reconnectCounter = 0
@@ -626,10 +616,7 @@ export class EngineState extends EventEmitter {
   pickNextTask (uri: string): StratumTask | void {
     const serverState = this.serverStates[uri]
     const connection = this.connections[uri]
-    const prefix = `${this.walletId.slice(0, 6)} ${uri.replace(
-      'electrum://',
-      ''
-    )}:`
+    const prefix = `${this.walletId} ${uri.replace('electrum://', '')}:`
 
     // Subscribe to height if this has never happened:
     if (serverState.height === void 0 && !serverState.fetchingHeight) {
@@ -830,7 +817,7 @@ export class EngineState extends EventEmitter {
   }
 
   async load () {
-    console.log(`${this.walletId.slice(0, 6)} - Loading wallet engine caches`)
+    console.log(`${this.walletId} - Loading wallet engine caches`)
 
     // Load transaction data cache:
     try {
@@ -925,12 +912,10 @@ export class EngineState extends EventEmitter {
           throw new Error('Missing addressFile')
         }
         await this.localFolder.file(this.addressFile).setText(json)
-        console.log(`${this.walletId.slice(0, 6)} - Saved address cache`)
+        console.log(`${this.walletId} - Saved address cache`)
         this.addressCacheDirty = false
       } catch (e) {
-        console.log(
-          `${this.walletId.slice(0, 6)} - saveAddressCache - ${e.toString()}`
-        )
+        console.log(`${this.walletId} - saveAddressCache - ${e.toString()}`)
       }
     }
   }
@@ -943,13 +928,10 @@ export class EngineState extends EventEmitter {
         }
         const json = JSON.stringify({ txs: this.txCache })
         await this.localFolder.file(this.txFile).setText(json)
-        console.log(`${this.walletId} - Saved tx cache`)
-        console.log(`${this.walletId.slice(0, 6)}: Saved txCache`)
+        console.log(`${this.walletId}: Saved txCache`)
         this.txCacheDirty = false
       } catch (e) {
-        console.log(
-          `${this.walletId.slice(0, 6)}: Error saving txCache: ${e.toString()}`
-        )
+        console.log(`${this.walletId}: Error saving txCache: ${e.toString()}`)
       }
     }
   }
@@ -1243,7 +1225,7 @@ export class EngineState extends EventEmitter {
   onConnectionClose (uri: string, task: string, e?: Error) {
     const msg = e ? `connection closed ERROR: ${e.message}` : `closed no error`
     console.log(
-      `${this.walletId.slice(0, 6)}: ${uri.replace(
+      `${this.walletId}: ${uri.replace(
         'electrum://',
         ''
       )}: ${msg}: task: ${task}`

--- a/src/engine/engineState.js
+++ b/src/engine/engineState.js
@@ -284,9 +284,7 @@ export class EngineState extends EventEmitter {
           if (++bad === uris.length) {
             const msg = e ? `With error ${e.toString()}` : ''
             console.log(
-              `${
-                this.walletId.slice(0, 6)
-              } broadcastTx fail: ${rawTx}\n${msg}}`
+              `${this.walletId.slice(0, 6)} broadcastTx fail: ${rawTx}\n${msg}}`
             )
             reject(e)
           }
@@ -526,9 +524,10 @@ export class EngineState extends EventEmitter {
       )
     }
     console.log(
-      `${
-        this.walletId.slice(0, 6)
-      }: refillServers: Top ${NEW_CONNECTIONS} servers:`,
+      `${this.walletId.slice(
+        0,
+        6
+      )}: refillServers: Top ${NEW_CONNECTIONS} servers:`,
       this.serverList
     )
     let chanceToBePicked = 1.25
@@ -557,7 +556,10 @@ export class EngineState extends EventEmitter {
         this.reconnect()
         break
       }
-      const prefix = `${this.walletId.slice(0, 6)} ${uri.replace('electrum://', '')}:`
+      const prefix = `${this.walletId.slice(0, 6)} ${uri.replace(
+        'electrum://',
+        ''
+      )}:`
       const callbacks: StratumCallbacks = {
         onOpen: () => {
           this.reconnectCounter = 0
@@ -624,7 +626,10 @@ export class EngineState extends EventEmitter {
   pickNextTask (uri: string): StratumTask | void {
     const serverState = this.serverStates[uri]
     const connection = this.connections[uri]
-    const prefix = `${this.walletId.slice(0, 6)} ${uri.replace('electrum://', '')}:`
+    const prefix = `${this.walletId.slice(0, 6)} ${uri.replace(
+      'electrum://',
+      ''
+    )}:`
 
     // Subscribe to height if this has never happened:
     if (serverState.height === void 0 && !serverState.fetchingHeight) {
@@ -765,7 +770,9 @@ export class EngineState extends EventEmitter {
           address,
           (hash: string | null) => {
             console.log(
-              `${prefix} subscribed to ${address} at ${hash ? hash.slice(0, 6) : 'null'}`
+              `${prefix} subscribed to ${address} at ${
+                hash ? hash.slice(0, 6) : 'null'
+              }`
             )
             addressState.subscribing = false
             addressState.subscribed = true
@@ -921,7 +928,9 @@ export class EngineState extends EventEmitter {
         console.log(`${this.walletId.slice(0, 6)} - Saved address cache`)
         this.addressCacheDirty = false
       } catch (e) {
-        console.log(`${this.walletId.slice(0, 6)} - saveAddressCache - ${e.toString()}`)
+        console.log(
+          `${this.walletId.slice(0, 6)} - saveAddressCache - ${e.toString()}`
+        )
       }
     }
   }
@@ -938,7 +947,9 @@ export class EngineState extends EventEmitter {
         console.log(`${this.walletId.slice(0, 6)}: Saved txCache`)
         this.txCacheDirty = false
       } catch (e) {
-        console.log(`${this.walletId.slice(0, 6)}: Error saving txCache: ${e.toString()}`)
+        console.log(
+          `${this.walletId.slice(0, 6)}: Error saving txCache: ${e.toString()}`
+        )
       }
     }
   }
@@ -1231,7 +1242,12 @@ export class EngineState extends EventEmitter {
 
   onConnectionClose (uri: string, task: string, e?: Error) {
     const msg = e ? `connection closed ERROR: ${e.message}` : `closed no error`
-    console.log(`${this.walletId.slice(0, 6)}: ${uri.replace('electrum://', '')}: ${msg}: task: ${task}`)
+    console.log(
+      `${this.walletId.slice(0, 6)}: ${uri.replace(
+        'electrum://',
+        ''
+      )}: ${msg}: task: ${task}`
+    )
     if (this.connections[uri]) {
       this.connections[uri].close(e)
     }

--- a/src/plugin/serverCache.js
+++ b/src/plugin/serverCache.js
@@ -153,9 +153,7 @@ export class ServerCache {
       this.setResponseTime(serverUrl, 9999)
     }
 
-    console.log(
-      `${serverUrl}: score DOWN to ${serverInfo.serverScore}`
-    )
+    console.log(`${serverUrl}: score DOWN to ${serverInfo.serverScore}`)
     this.dirtyServerCache(serverUrl)
   }
 

--- a/src/plugin/serverCache.js
+++ b/src/plugin/serverCache.js
@@ -129,9 +129,9 @@ export class ServerCache {
     }
 
     console.log(
-      `Stratum ${serverUrl} score went UP ${
+      `${serverUrl}: score UP to ${
         serverInfo.serverScore
-      } ${responseTimeMilliseconds}`
+      } ${responseTimeMilliseconds}ms`
     )
     this.dirtyServerCache(serverUrl)
   }
@@ -154,7 +154,7 @@ export class ServerCache {
     }
 
     console.log(
-      `Stratum ${serverUrl} score went DOWN ${serverInfo.serverScore}`
+      `${serverUrl}: score DOWN to ${serverInfo.serverScore}`
     )
     this.dirtyServerCache(serverUrl)
   }

--- a/src/utils/coinUtils.js
+++ b/src/utils/coinUtils.js
@@ -163,8 +163,9 @@ export const createTX = async ({
   const toBcoinFormat = (address: string, network: string): string => {
     const { addressPrefix = {}, serializers = {} } = networks[network] || {}
     if (serializers.address) address = serializers.address.decode(address)
-    else if (addressPrefix.cashAddress) address = toLegacyFormat(address, network)
-    else address = toNewFormat(address, network)
+    else if (addressPrefix.cashAddress) {
+      address = toLegacyFormat(address, network)
+    } else address = toNewFormat(address, network)
     return primitives.Address.fromString(address, network)
   }
 

--- a/src/utils/formatSelector.js
+++ b/src/utils/formatSelector.js
@@ -102,7 +102,9 @@ export const FormatSelector = (
         })
         .then(() => {
           const { serializers = {} } = networks[network] || {}
-          if (serializers.txHash) tx._hash = serializers.txHash(tx.toNormal().toString('hex'))
+          if (serializers.txHash) {
+            tx._hash = serializers.txHash(tx.toNormal().toString('hex'))
+          }
           const txid = tx.rhash()
           return { txid, signedTx: tx.toRaw().toString('hex') }
         }),


### PR DESCRIPTION
* Only show first 6 chars of wallet ID
* Paraphrase some logging descriptions
* Remove "electrum://" from url logging

This helps when trying to sequence of what happened during network issues