### PR TITLE
Throttle the calls to update the fee correctly

### DIFF
--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -288,9 +288,9 @@ export class CurrencyEngine {
         const url = `${InfoServer}/networkFees/${this.currencyCode}`
         const feesResponse = await this.io.fetch(url)
         const feesJson = await feesResponse.json()
+        this.fees.timestamp = Date.now()
         if (validateObject(feesJson, InfoServerFeesSchema)) {
           this.fees = feesJson
-          this.fees.timestamp = Date.now()
         } else {
           throw new Error('Fetched invalid networkFees')
         }


### PR DESCRIPTION
Set the timestamp after we requested fees from the server no matter the outcome of the result.
It fixes this bug:
https://app.asana.com/0/361770107085503/714313720551065/f