### PR TITLE
Add EBoost Support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import { qtum } from './info/qtum'
 import { ufo } from './info/ufo'
 import { vertcoin } from './info/vertcoin'
 import { zcoin } from './info/zcoin'
+import { eboost } from './info/eboost'
 
 export const bitcoinCurrencyPluginFactory = makeCurrencyPluginFactory(bitcoin)
 export const bitcoinTestnetCurrencyPluginFactory = makeCurrencyPluginFactory(bitcoinTestnet)
@@ -31,3 +32,4 @@ export const qtumCurrencyPluginFactory = makeCurrencyPluginFactory(qtum)
 export const ufoCurrencyPluginFactory = makeCurrencyPluginFactory(ufo)
 export const vertcoinCurrencyPluginFactory = makeCurrencyPluginFactory(vertcoin)
 export const zcoinCurrencyPluginFactory = makeCurrencyPluginFactory(zcoin)
+export const eboostCurrencyPluginFactory = makeCurrencyPluginFactory(eboost)

--- a/src/info/eboost.js
+++ b/src/info/eboost.js
@@ -1,0 +1,93 @@
+// @flow
+import type { EdgeCurrencyInfo } from 'edge-core-js'
+import type { EngineCurrencyInfo } from '../engine/currencyEngine.js'
+import type { BcoinCurrencyInfo } from '../utils/bcoinExtender/bcoinExtender.js'
+import { imageServerUrl } from './constants.js'
+
+const bcoinInfo: BcoinCurrencyInfo = {
+  type: 'eboost',
+  magic: 0xd9b4bef9,
+  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
+  keyPrefix: {
+    privkey: 0xb0,
+    xpubkey: 0x0488b21e,
+    xprivkey: 0x0488ade4,
+    xpubkey58: 'xpub',
+    xprivkey58: 'xprv',
+    coinType: 2
+  },
+  addressPrefix: {
+    pubkeyhash: 0x5c,
+    scripthash: 0x0a,
+    scripthashLegacy: 0x05,
+    witnesspubkeyhash: 0x06,
+    witnessscripthash: 0x0a,
+    bech32: 'ebst'
+  }
+}
+
+const engineInfo: EngineCurrencyInfo = {
+  network: 'eboost',
+  currencyCode: 'EBST',
+  gapLimit: 10,
+  maxFee: 1000000,
+  defaultFee: 50000,
+  feeUpdateInterval: 60000,
+  infoServer: 'https://info1.edgesecure.co:8444/v1',
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '300',
+    lowFee: '100',
+    standardFeeLow: '150',
+    standardFeeHigh: '200',
+    standardFeeLowAmount: '20000000',
+    standardFeeHighAmount: '981000000'
+  }
+}
+
+const currencyInfo: EdgeCurrencyInfo = {
+  // Basic currency information:
+  currencyCode: 'EBST',
+  currencyName: 'eBoost',
+  pluginName: 'eboost',
+  denominations: [
+    { name: 'EBST', multiplier: '100000000', symbol: 'EBST' },
+    { name: 'mEBST', multiplier: '100000', symbol: 'mEBST' }
+  ],
+
+  // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  // !!!!!!!!!!!!!!! - About to be deprecated - !!!!!!!!!!!!!!!!!!!
+  // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  walletTypes: [
+    'wallet:eboost-bip84',
+    'wallet:eboost-bip49',
+    'wallet:eboost-bip44',
+    'wallet:eboost'
+  ],
+
+  // Configuration options:
+  defaultSettings: {
+    customFeeSettings: ['satPerByte'],
+    electrumServers: [
+      'electrums://electrum1.eboost.fun:50002',
+      'electrums://electrum2.eboost.fun:50002',
+      'electrums://electrum3.eboost.fun:50002',
+      'electrum://electrum1.eboost.fun:50001',
+      'electrum://electrum2.eboost.fun:50001',
+      'electrum://electrum3.eboost.fun:50001'
+    ],
+    disableFetchingServers: true
+  },
+  metaTokens: [],
+
+  // Explorers:
+  addressExplorer: 'https://www.blockexperts.com/ebst/address/%s',
+  blockExplorer: 'https://www.blockexperts.com/ebst/hash/%s',
+  transactionExplorer: 'https://www.blockexperts.com/ebst/tx/%s',
+
+  // Images:
+  symbolImage: `${imageServerUrl}/eboost-logo-64.png`,
+  symbolImageDarkMono: `${imageServerUrl}/eboost-logo-64.png`
+}
+
+export const eboost = { bcoinInfo, engineInfo, currencyInfo }

--- a/src/info/eboost.js
+++ b/src/info/eboost.js
@@ -58,12 +58,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   // !!!!!!!!!!!!!!! - About to be deprecated - !!!!!!!!!!!!!!!!!!!
   // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  walletTypes: [
-    'wallet:eboost-bip84',
-    'wallet:eboost-bip49',
-    'wallet:eboost-bip44',
-    'wallet:eboost'
-  ],
+  walletTypes: ['wallet:eboost'],
 
   // Configuration options:
   defaultSettings: {

--- a/src/utils/addressFormat/addressFormatIndex.js
+++ b/src/utils/addressFormat/addressFormatIndex.js
@@ -36,7 +36,13 @@ export const switchLegacy = (
     if (mode === 'toNew') return legacyToCashAddress(address, network)
   }
   try {
-    const addressObj = bcoin.primitives.Address.fromBase58(address)
+    let addressObj = {}
+    if (mode === 'toLegacy') {
+      addressObj = bcoin.primitives.Address.fromBase58(address, network)
+    }
+    if (mode === 'toNew') {
+      addressObj = bcoin.primitives.Address.fromBase58(address)
+    }
     const type = addressObj.getType()
     const legacyPrefix = addressPrefix[`${type}Legacy`]
     if (!legacyPrefix) return address
@@ -97,7 +103,7 @@ export const validAddress = (address: string, network: string) => {
     }
   }
   try {
-    const prefix = bcoin.primitives.Address.fromBase58(address).getPrefix()
+    const prefix = bcoin.primitives.Address.fromBase58(address, network).getPrefix()
     const { pubkeyhash, scripthash } = bcoin.networks[network].addressPrefix
     if (prefix !== pubkeyhash && prefix !== scripthash) return false
   } catch (e) {

--- a/test/utils/addressFormat/addressFormatIndex/fixtures.json
+++ b/test/utils/addressFormat/addressFormatIndex/fixtures.json
@@ -528,5 +528,75 @@
       [ "QfFE2wjWdqPDX4TQESSdEyb5y9DqL5wYHA", "QfFE2wjWdqPDX4TQESSdEyb5y9DqL5wYHA" ],
       [ "M816EdyuvWV7oETCfQeZb5mGWm9nHczijH", "M816EdyuvWV7oETCfQeZb5mGWm9nHczijH" ]
     ]
+  },
+  {
+    "network": "eboost",
+    "valid": [
+      "e5EYr11Uvghiq4SebDT2YUhBzZHScCoyPe",
+      "eNXXXXXXXXXXXXXXXXXXXXXXXXXXXviVRh",
+      "e8M37vArBf28RbAeVsEKdsMTf8y4eFLbkc",
+      "eNgz9mTPLaatC6cAhHDGZz9yUPBVEqobZB",
+      "5DCGZBCYJy71oSfky6DXHsuWqMW3yqiJiS",
+      "5LutMcbbX2CEzkLH26gC4rfjcFuyHYHKCd",
+      "52UxrJ4PXHx55tsjgdKpC4soLar3p52vcm",
+      "5FAyQxqcVJ4Qeyt4qw6UxnGtf3jUArd1Gc"
+    ],
+    "inValid": [
+      "1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu",
+      "1KXrWXciRDZUpQwQmuM1DbwsKDLYAYsVLR",
+      "16w1D5WRVKJuZUsSRzdLp9w3YGcgoxDXb",
+      "18uKBY8mgA7MWfRHpw8faQRZQtssqXWSJS",
+      "QUMjbkZ8NtBrPnEcBD67oYvnyqQjHdARcg",
+      "QRZbPEVbUcZVpdhRqQZ5JiTksFbt67tzxt",
+      "QWGYZXGCtancAVcCPsAoidrKBqJuB6v7Zr",
+      "Qi8t89jduvEpncyHjA3zt66d5KCZZx6vWA",
+      "QPoVZqSCxtWkHgNt8jkipv6KNJUMmE7gRT",
+      "QNAp1HbJjPfUgvnkd8jgr71UYogs4zpcan",
+      "QNqKeSsHjZfbVxB2jkpDUgGcZvSheWKhCw",
+      "QfFE2wjWdqPDX4TQESSdEyb5y9DqL5wYHA",
+      "QLn8CDS8TiZH3RHCdbf7ensHKW6BWCY8B5",
+      "MSS1jxX7vEjHi5ujzszwTsZCnSDhkWKrBd",
+      "M816EdyuvWV7oETCfQeZb5mGWm9nHczijH",
+      "MJiPwX84iBe4WnFDwsYGgtnz1XonPhUqhf",
+      "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+      "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
+      "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+      "bc1qc7slrfxkknqcq2jevvvkdgvrt8080852dfjewde450xdlk4ugp7szw5tk9",
+      "XekiLaxnqpFb2m4NQAEcsKutZcZgcyfo6W",
+      "XiBQaGtW6y1C52YtPBD4PTMntpA9hkBq5p",
+      "XqWgAZEGdWDUhbS1YxSwxrK3GLGdJjSHus",
+      "XbtvGzi2JgjYTbTqabUjSREWeovDxznoyh",
+      "Xx9R3uriMAF2W71WH5kwpNdoHxqzGGih3c",
+      "Xm9TJiJ7nWjme8K7iEPUGsC5JjYGzPk2QU",
+      "XvwKzdsn46psqy6WhZ2wfhRPyRkD6GL2BG",
+      "LQL9pVH1LsMfKwt82Y2wGhNGkrjF8vwUst",
+      "LPpHectVSbk7YHa5X89Cm3FoFBfzkJBJc9",
+      "LRcYfbDMhwvXaGPFccaKuc3fZD1Nb55aGn",
+      "LY5fxZS74Ewuj1TTHwat23eUmZwimsksrU",
+      "LdP8Qox1VAhCzLJNqrr74YovaWYyNBUWvL",
+      "Laub752qu81oWwkNKEyawyKruUC6cEyD2x",
+      "LbHBMZTQBq7aM5WS5TeKYJWH8pxeaLoRXe",
+      "LPpVeFSKvH593CChqP9qpV5toEXntekjiF",
+      "LfmG6qepmucU2aQaVJK4EJgBzQHeGz5ML4",
+      "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a",
+      "bitcoincash:qr95sy3j9xwd2ap32xkykttr4cvcu7as4y0qverfuy",
+      "bitcoincash:qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r",
+      "bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq",
+      "bitcoincash:pr95sy3j9xwd2ap32xkykttr4cvcu7as4yc93ky28e",
+      "bitcoincash:pqq3728yw0y47sqn6l2na30mcw6zm78dzq5ucqzc37",
+      "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a"
+    ],
+    "toLegacy": [
+      [ "5DCGZBCYJy71oSfky6DXHsuWqMW3yqiJiS", "3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC" ],
+      [ "5LutMcbbX2CEzkLH26gC4rfjcFuyHYHKCd", "3LDsS579y7sruadqu11beEJoTjdFiFCdX4" ], 
+      [ "52UxrJ4PXHx55tsjgdKpC4soLar3p52vcm", "31nwvkZwyPdgzjBJZXfDmSWsC4ZLKpYyUw" ], 
+      [ "5FAyQxqcVJ4Qeyt4qw6UxnGtf3jUArd1Gc", "3EUxVRMAwPk2ZpBdiqRtY9uxWXSkgVCTFN" ]
+    ],
+    "toNewFormat": [
+      [ "3CWFddi6m4ndiGyKqzYvsFYagqDLPVMTzC", "5DCGZBCYJy71oSfky6DXHsuWqMW3yqiJiS" ],
+      [ "3LDsS579y7sruadqu11beEJoTjdFiFCdX4", "5LutMcbbX2CEzkLH26gC4rfjcFuyHYHKCd" ], 
+      [ "31nwvkZwyPdgzjBJZXfDmSWsC4ZLKpYyUw", "52UxrJ4PXHx55tsjgdKpC4soLar3p52vcm" ], 
+      [ "3EUxVRMAwPk2ZpBdiqRtY9uxWXSkgVCTFN", "5FAyQxqcVJ4Qeyt4qw6UxnGtf3jUArd1Gc" ]
+    ]
   }
 ]


### PR DESCRIPTION
Add EBoost Support and fix some buggy edge cases that happened since EBoost's new format overlaps with another network's prefix.

No need to review the file `src/info/eboost.js` or the tests.