### PR TITLE
skip sending tx on brodcasters when user added a custom node

### DIFF
--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -685,10 +685,13 @@ export class CurrencyEngine {
 
     // Try APIs
     const promiseArray = []
-    for (const broadcastFactory of broadcastFactories) {
-      const broadcaster = broadcastFactory(this.io, currencyCode)
-      if (broadcaster) promiseArray.push(broadcaster(signedTx))
+    if (!this.pluginState.disableFetchingServers) {
+      for (const broadcastFactory of broadcastFactories) {
+        const broadcaster = broadcastFactory(this.io, currencyCode)
+        if (broadcaster) promiseArray.push(broadcaster(signedTx))
+      }
     }
+
     promiseArray.push(this.engineState.broadcastTx(signedTx))
     await promiseAny(promiseArray)
     return edgeTransaction


### PR DESCRIPTION
A fix to solve asana task "Custom Nodes - Still able to send and detect transactions even if turned on with an invalid server"