### PR TITLE
Fix BitPay fee calculation

### DIFF
--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -351,7 +351,7 @@ export class CurrencyEngine {
     ) {
       const requiredFeeRate =
         otherParams.paymentProtocolInfo.merchant.requiredFeeRate
-      return parseInt(requiredFeeRate) * BYTES_TO_KB * 1.5
+      return Math.ceil(parseFloat(requiredFeeRate) * BYTES_TO_KB * 1.5)
     }
     const customFeeSetting = this.engineInfo.customFeeSettings[0]
     const customFeeAmount = customNetworkFee[customFeeSetting] || '0'


### PR DESCRIPTION
If BitPay sends a floating-point fee, we would round it down to the nearest integer and therefore send too little. This calculation keeps the fee in float until the end, and then rounds up.