### PR TITLE
Disable `derivePublicKey` for now

### DIFF
--- a/src/plugin/currencyPlugin.js
+++ b/src/plugin/currencyPlugin.js
@@ -98,6 +98,10 @@ export class CurrencyTools {
   }
 
   async derivePublicKey (walletInfo: EdgeWalletInfo) {
+    return {}
+  }
+
+  async internalDerivePublicKey (walletInfo: EdgeWalletInfo) {
     if (!walletInfo.keys) throw new Error('InvalidKeyName')
     const network = this.network
     const { format, coinType = -1 } = walletInfo.keys

--- a/test/engine/currencyEngine/currencyEngine.js
+++ b/test/engine/currencyEngine/currencyEngine.js
@@ -114,7 +114,12 @@ for (const dir of dirs(FIXTURES_FOLDER)) {
         coinType: 0,
         format: WALLET_FORMAT
       })
-      keys = await tools.derivePublicKey({ type: WALLET_TYPE, keys, id: '!' })
+      // $FlowFixMe
+      keys = await tools.internalDerivePublicKey({
+        type: WALLET_TYPE,
+        keys,
+        id: '!'
+      })
     })
 
     it('Error when Making Engine without local folder', function () {

--- a/test/plugin/currencyPlugin/currencyPlugin.js
+++ b/test/plugin/currencyPlugin/currencyPlugin.js
@@ -71,7 +71,7 @@ for (const fixture of fixtures) {
     })
   })
 
-  describe(`derivePublicKey for Wallet type ${WALLET_TYPE}`, function () {
+  describe.skip(`derivePublicKey for Wallet type ${WALLET_TYPE}`, function () {
     it('Valid private key', function (done) {
       tools
         .derivePublicKey({


### PR DESCRIPTION
This will fix both the performance problem and the `InvalidWalletType` errors.