### PR TITLE
Fix BCH -> BSV splitting

### DIFF
--- a/src/engine/keyManager.js
+++ b/src/engine/keyManager.js
@@ -402,8 +402,6 @@ export class KeyManager {
           closeGaps
         )
       }
-    } catch (e) {
-      console.log(e)
     } finally {
       unlock()
     }

--- a/src/utils/coinUtils.js
+++ b/src/utils/coinUtils.js
@@ -126,7 +126,7 @@ export const setKeyType = async (
     witness = false
     keyRing = await primitives.KeyRing.fromScript(
       key.privateKey || key.publicKey,
-      script.fromString(redeemScript),
+      script.fromRaw(Buffer.from(redeemScript.replace(/^0x/, ''), 'hex')),
       isCompressed(key.publicKey),
       network
     )


### PR DESCRIPTION
All BCH wallets would crash on first login, but there was bogus catch statement hiding the error. Removing the catch statement exposes the error, which is passing hex data into a method that expects script (like "OP_X OP_Y"). Changing the method fixes the issue.