### PR TITLE
Change logger error to warn to prevent red screen of death in GUI

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -8,5 +8,5 @@ export const setLogger = (printer: EdgeConsole) => {
   // $FlowFixMe
   logger.warn = printer.warn
   // $FlowFixMe
-  logger.error = printer.error
+  logger.error = printer.warn
 }


### PR DESCRIPTION
The purpose of this task is to change the plugin errors to warning-level so that they don't create a red screen of death in the GUI