### PR TITLE
Add server score up to subscribe hash

### DIFF
--- a/src/engine/engineState.js
+++ b/src/engine/engineState.js
@@ -768,6 +768,7 @@ export class EngineState extends EventEmitter {
       const addressState = serverState.addresses[address]
       if (!addressState.subscribed && !addressState.subscribing) {
         addressState.subscribing = true
+        const queryTime = Date.now()
         return subscribeScriptHash(
           address,
           (hash: string | null) => {
@@ -776,6 +777,7 @@ export class EngineState extends EventEmitter {
                 hash ? hash.slice(0, 6) : 'null'
               }`
             )
+            this.pluginState.serverScoreUp(uri, Date.now() - queryTime, 0)
             addressState.subscribing = false
             addressState.subscribed = true
             addressState.hash = hash


### PR DESCRIPTION
This keeps the "lastScoreUpTime_" refreshed so the serverCache doesn't think we are offline