### PR TITLE
Include debugInfo in transaction otherParams field

### DIFF
--- a/src/engine/broadcastApi.js
+++ b/src/engine/broadcastApi.js
@@ -2,8 +2,8 @@
 
 import { type EdgeIo } from 'edge-core-js/types'
 
-import { logger } from '../utils/logger.js'
 import { allInfo } from '../info/all.js'
+import { logger } from '../utils/logger.js'
 
 const makeBroadcastBlockchainInfo = (io: EdgeIo, currencyCode: string) => {
   const supportedCodes = ['BTC']
@@ -102,10 +102,15 @@ const makeBroadcastBlockchair = (io: EdgeIo, currencyCode: string) => {
       if (out.context && out.context.error) {
         logger.info('makeBroadcastBlockchair fail with out: ', out)
         throw new Error(
-          `https://api.blockchair.com/${pluginName}/push/transaction failed with error ${out.context.error}`
+          `https://api.blockchair.com/${pluginName}/push/transaction failed with error ${
+            out.context.error
+          }`
         )
       }
-      logger.info('makeBroadcastBlockchair executed successfully with hash: ', out.data.transaction_hash)
+      logger.info(
+        'makeBroadcastBlockchair executed successfully with hash: ',
+        out.data.transaction_hash
+      )
       return out.data.transaction_hash
     } catch (e) {
       logger.info('ERROR makeBroadcastBlockchair: ', e)

--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -250,11 +250,16 @@ export class CurrencyEngine {
       this.network,
       this.engineState
     )
-
+    const sizes = bcoinTransaction.getSizes()
+    const debugInfo = `Inputs: ${bcoinTransaction.inputs.length}\nOutputs: ${
+      bcoinTransaction.outputs.length
+    }\nSize: ${sizes.size}\nWitness: ${sizes.witness}`
     const edgeTransaction: EdgeTransaction = {
       ourReceiveAddresses,
       currencyCode: this.currencyCode,
-      otherParams: {},
+      otherParams: {
+        debugInfo
+      },
       txid: txid,
       date: date,
       blockHeight: height === -1 ? 0 : height,

--- a/src/engine/keyManager.js
+++ b/src/engine/keyManager.js
@@ -84,7 +84,7 @@ export interface KeyManagerCallbacks {
 type BasicEngineState = {
   addressInfos: { [scriptHash: string]: AddressInfo },
   parsedTxs: { [txid: string]: any },
-  scriptHashes: { [displayAddress: string]: string },
+  scriptHashes: { [displayAddress: string]: string }
 }
 
 export type KeyManagerOptions = {


### PR DESCRIPTION
Include bcoin's data regarding inputs, outputs, size, and witness size
into EdgeTransaction's otherparams.debugInfo for debugging purposes

WIP inputs and outputs

Change otherParams inputs and outputs to general debugInfo string