### PR TITLE
Don't send a `maxFee` to the bcoin picker

### DIFF
--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -65,7 +65,6 @@ export type EngineCurrencyInfo = {
   network: string, // The offical network in lower case - Needs to match the Bitcoin Lib Network Type
   currencyCode: string, // The offical currency code in upper case - Needs to match the EdgeCurrencyInfo currencyCode
   gapLimit: number,
-  maxFee: number,
   defaultFee: number,
   feeUpdateInterval: number,
   customFeeSettings: Array<string>,
@@ -588,7 +587,6 @@ export class CurrencyEngine {
         utxos,
         rate,
         txOptions,
-        maxFee: this.engineInfo.maxFee,
         height: this.getBlockHeight()
       })
 

--- a/src/engine/keyManager.js
+++ b/src/engine/keyManager.js
@@ -59,7 +59,6 @@ export type createTxOptions = {
   utxos: Array<Utxo>,
   height: BlockHeight,
   rate: number,
-  maxFee: number,
   txOptions: TxOptions
 }
 

--- a/src/info/bitcoin.js
+++ b/src/info/bitcoin.js
@@ -32,7 +32,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'bitcoin',
   currencyCode: 'BTC',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 1000,
   feeUpdateInterval: 60000,
   feeInfoServer: 'https://Bitcoinfees.Earn.com/api/v1/fees/list',

--- a/src/info/bitcoincash.js
+++ b/src/info/bitcoincash.js
@@ -85,7 +85,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'bitcoincash',
   currencyCode: 'BCH',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 10000,
   feeUpdateInterval: 60000,
   customFeeSettings: ['satPerByte'],

--- a/src/info/bitcoincashtestnet.js
+++ b/src/info/bitcoincashtestnet.js
@@ -34,7 +34,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'bitcoincashtestnet',
   currencyCode: 'TBCH',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 10000,
   feeUpdateInterval: 60000,
   feeInfoServer: '',

--- a/src/info/bitcoingold.js
+++ b/src/info/bitcoingold.js
@@ -36,7 +36,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'bitcoingold',
   currencyCode: 'BTG',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 1000,
   feeUpdateInterval: 60000,
   feeInfoServer: '',

--- a/src/info/bitcoingoldtestnet.js
+++ b/src/info/bitcoingoldtestnet.js
@@ -36,7 +36,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'bitcoingold',
   currencyCode: 'TBTG',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 1000,
   feeUpdateInterval: 60000,
   feeInfoServer: '',

--- a/src/info/bitcoinsv.js
+++ b/src/info/bitcoinsv.js
@@ -34,7 +34,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'bitcoinsv',
   currencyCode: 'BSV',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 10000,
   feeUpdateInterval: 60000,
   customFeeSettings: ['satPerByte'],

--- a/src/info/bitcointestnet.js
+++ b/src/info/bitcointestnet.js
@@ -41,7 +41,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'bitcointestnet',
   currencyCode: 'TBTC',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 1000,
   feeUpdateInterval: 60000,
   feeInfoServer: '',

--- a/src/info/dash.js
+++ b/src/info/dash.js
@@ -28,7 +28,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'dash',
   currencyCode: 'DASH',
   gapLimit: 10,
-  maxFee: 100000,
   defaultFee: 10000,
   feeUpdateInterval: 60000,
   customFeeSettings: ['satPerByte'],

--- a/src/info/digibyte.js
+++ b/src/info/digibyte.js
@@ -33,7 +33,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'digibyte',
   currencyCode: 'DGB',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 1000,
   feeUpdateInterval: 60000,
   customFeeSettings: ['satPerByte'],

--- a/src/info/dogecoin.js
+++ b/src/info/dogecoin.js
@@ -28,7 +28,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'dogecoin',
   currencyCode: 'DOGE',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 1000,
   feeUpdateInterval: 10000,
   customFeeSettings: ['satPerByte'],

--- a/src/info/eboost.js
+++ b/src/info/eboost.js
@@ -28,7 +28,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'eboost',
   currencyCode: 'EBST',
   gapLimit: 10,
-  maxFee: 10000000,
   defaultFee: 500000,
   feeUpdateInterval: 60000,
   infoServer: 'https://info1.edgesecure.co:8444/v1',

--- a/src/info/feathercoin.js
+++ b/src/info/feathercoin.js
@@ -31,7 +31,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'feathercoin',
   currencyCode: 'FTC',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 1000,
   feeUpdateInterval: 60000,
   customFeeSettings: ['satPerByte'],

--- a/src/info/groestlcoin.js
+++ b/src/info/groestlcoin.js
@@ -69,7 +69,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'groestlcoin',
   currencyCode: 'GRS',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 100000,
   feeUpdateInterval: 60000,
   customFeeSettings: ['satPerByte'],

--- a/src/info/litecoin.js
+++ b/src/info/litecoin.js
@@ -32,7 +32,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'litecoin',
   currencyCode: 'LTC',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 50000,
   feeUpdateInterval: 60000,
   customFeeSettings: ['satPerByte'],

--- a/src/info/qtum.js
+++ b/src/info/qtum.js
@@ -28,7 +28,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'qtum',
   currencyCode: 'QTUM',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 1000,
   feeUpdateInterval: 60000,
   customFeeSettings: ['satPerByte'],

--- a/src/info/ravencoin.js
+++ b/src/info/ravencoin.js
@@ -28,7 +28,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'ravencoin',
   currencyCode: 'RVN',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 1000,
   feeUpdateInterval: 60000,
   customFeeSettings: ['satPerByte'],

--- a/src/info/smartcash.js
+++ b/src/info/smartcash.js
@@ -57,7 +57,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'smartcash',
   currencyCode: 'SMART',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 100000,
   feeUpdateInterval: 60000,
   customFeeSettings: ['satPerByte'],

--- a/src/info/ufo.js
+++ b/src/info/ufo.js
@@ -32,7 +32,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'uniformfiscalobject',
   currencyCode: 'UFO',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 50000,
   feeUpdateInterval: 60000,
   customFeeSettings: ['satPerByte'],

--- a/src/info/vertcoin.js
+++ b/src/info/vertcoin.js
@@ -32,7 +32,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'vertcoin',
   currencyCode: 'VTC',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 1000,
   feeUpdateInterval: 60000,
   customFeeSettings: ['satPerByte'],

--- a/src/info/zcoin.js
+++ b/src/info/zcoin.js
@@ -28,7 +28,6 @@ const engineInfo: EngineCurrencyInfo = {
   network: 'zcoin',
   currencyCode: 'XZC',
   gapLimit: 10,
-  maxFee: 1000000,
   defaultFee: 1000,
   feeUpdateInterval: 60000,
   customFeeSettings: ['satPerByte'],

--- a/src/utils/coinUtils.js
+++ b/src/utils/coinUtils.js
@@ -60,7 +60,6 @@ export type TxOptions = {
 export type CreateTxOptions = {
   utxos: Array<Utxo>,
   rate: number,
-  maxFee: number,
   changeAddress: string,
   network: string,
   outputs?: Array<StandardOutput>,
@@ -149,7 +148,6 @@ export const createTX = async ({
   outputs = [],
   changeAddress,
   rate,
-  maxFee,
   height = -1,
   estimate,
   network,
@@ -225,7 +223,6 @@ export const createTX = async ({
     subtractFee,
     height,
     rate,
-    maxFee,
     estimate
   })
 


### PR DESCRIPTION
Hitting the `maxFee` looks like an `InsufficientFundsError`, which is wrong. The GUI has its own fiat-based fee warnings, so we don't need this.