### PR TITLE
Allow merge-mined Dogecoin blocks

### DIFF
--- a/src/info/dogecoin.js
+++ b/src/info/dogecoin.js
@@ -38,6 +38,12 @@ const engineInfo: EngineCurrencyInfo = {
     standardFeeHigh: '750',
     standardFeeLowAmount: '2000000000',
     standardFeeHighAmount: '98100000000'
+  },
+  timestampFromHeader (header: Buffer): number {
+    if (header.length < 80) {
+      throw new Error(`Cannot interpret block header ${header.toString('hex')}`)
+    }
+    return header.readUInt32LE(4 + 32 + 32)
   }
 }
 


### PR DESCRIPTION
Dogecoin has [merged mining](https://en.bitcoin.it/wiki/Merged_mining_specification), which means the headers can be other sizes than 80 bytes.