### PR TITLE
Remove the bitcoin-centric sanity checks

### DIFF
--- a/src/utils/coinUtils.js
+++ b/src/utils/coinUtils.js
@@ -271,11 +271,6 @@ export const createTX = async ({
     }
   }
 
-  // Check consensus rules for fees and outputs
-  if (!mtx.isSane()) {
-    throw new Error('TX failed sanity check.')
-  }
-
   // Check consensus rules for inputs
   if (height !== -1 && !mtx.verifyInputs(height)) {
     throw new Error('TX failed context check.')


### PR DESCRIPTION
These checks don't make sense for other coins, and are actually making big wallets (with > 21 million coins) un-spendable.