### PR TITLE
William/upgrade core

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@babel/runtime": "^7.0.0",
     "babel-eslint": ">=10.0.0",
     "babel-loader": "^8.0.5",
-    "edge-core-js": "0.16.17",
+    "edge-core-js": "0.16.20",
     "eslint": ">=6.2.2",
     "eslint-config-standard-kit": ">=0.14.2",
     "eslint-plugin-flowtype": ">=4.3.0",

--- a/src/engine/broadcastApi.js
+++ b/src/engine/broadcastApi.js
@@ -11,23 +11,26 @@ const makeBroadcastBlockchainInfo = (io: PluginIo, currencyCode: string) => {
   }
   return async (rawTx: string) => {
     try {
-      const response: string = await io.fetchText(
-        'https://blockchain.info/pushtx',
-        {
-          method: 'POST',
-          body: 'tx=' + rawTx,
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
-        }
-      )
-      if (response === 'Transaction Submitted') {
+      const { fetchCors = io.fetch } = io
+      const uri = 'https://blockchain.info/pushtx'
+      const response = await fetchCors(uri, {
+        method: 'POST',
+        body: 'tx=' + rawTx,
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+      })
+      if (!response.ok) {
+        throw new Error(`Error ${response.status} while fetching ${uri}`)
+      }
+      const responseText = await response.text()
+      if (responseText === 'Transaction Submitted') {
         logger.info(
           'SUCCESS makeBroadcastBlockchainInfo has response',
           response
         )
         return true
       } else {
-        logger.info('ERROR makeBroadcastBlockchainInfo', response)
-        throw new Error(`blockchain.info failed with status ${response}`)
+        logger.info('ERROR makeBroadcastBlockchainInfo', responseText)
+        throw new Error(`blockchain.info failed with status ${responseText}`)
       }
     } catch (e) {
       logger.info('ERROR makeBroadcastBlockchainInfo', e)
@@ -49,22 +52,20 @@ const makeBroadcastInsight = (io: PluginIo, currencyCode: string) => {
 
   return async (rawTx: string) => {
     try {
-      const response = await io.fetch(urls[currencyCode], {
+      const uri = urls[currencyCode]
+      const response = await io.fetch(uri, {
         method: 'POST',
         body: 'rawtx=' + rawTx,
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
       })
-      if (response.ok) {
-        const out = await response.json()
-        if (out.txid) {
-          logger.info('SUCCESS makeBroadcastInsight:' + JSON.stringify(out))
-          return out
-        }
+      if (!response.ok) {
+        throw new Error(`Error ${response.status} while fetching ${uri}`)
       }
-      logger.info('ERROR makeBroadcastInsight', response)
-      throw new Error(
-        `${urls[currencyCode]} failed with status ${response.status}`
-      )
+      const out = await response.json()
+      if (out.txid) {
+        logger.info('SUCCESS makeBroadcastInsight:' + JSON.stringify(out))
+        return out
+      }
     } catch (e) {
       logger.info('ERROR makeBroadcastInsight:', e)
       throw e
@@ -93,18 +94,20 @@ const makeBroadcastBlockchair = (io: PluginIo, currencyCode: string) => {
   return async (rawTx: string) => {
     try {
       const body = { data: rawTx }
-      const response = await io.fetchJson(
-        `https://api.blockchair.com/${pluginName}/push/transaction`,
-        {
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json'
-          },
-          method: 'POST',
-          body: JSON.stringify(body)
-        }
-      )
-      const out = await response
+      const { fetchCors = io.fetch } = io
+      const uri = `https://api.blockchair.com/${pluginName}/push/transaction`
+      const response = await fetchCors(uri, {
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json'
+        },
+        method: 'POST',
+        body: JSON.stringify(body)
+      })
+      if (!response.ok) {
+        throw new Error(`Error ${response.status} while fetching ${uri}`)
+      }
+      const out = await response.json()
       logger.info(
         'makeBroadcastBlockchair fetch with body: ',
         body,

--- a/src/index.js
+++ b/src/index.js
@@ -10,17 +10,13 @@ import {
   type EdgeSocket,
   type EdgeSocketOptions,
   type PluginIo,
-  makeEdgeSocket,
-  makeFetchJson,
-  makeFetchText
+  makeEdgeSocket
 } from './plugin/pluginIo.js'
 
 export function makeNodeIo(io: EdgeIo): PluginIo {
   const { secp256k1, pbkdf2 } = crypto
   return {
     ...io,
-    fetchJson: makeFetchJson(io),
-    fetchText: makeFetchText(io),
     pbkdf2,
     secp256k1,
     makeSocket(opts: EdgeSocketOptions): Promise<EdgeSocket> {

--- a/src/plugin/pluginIo.js
+++ b/src/plugin/pluginIo.js
@@ -3,9 +3,6 @@
 import { type EdgeIo } from 'edge-core-js/types'
 import { type Subscriber, bridgifyObject, emit, onMethod } from 'yaob'
 
-export type FetchJson = (uri: string, opts?: Object) => Promise<Object>
-export type FetchText = (uri: string, opts?: Object) => Promise<string>
-
 export type EdgeSecp256k1 = {
   publicKeyCreate: (
     privateKey: Uint8Array,
@@ -99,34 +96,10 @@ export function makeEdgeSocket(
   return out
 }
 
-export function makeFetchJson(io: EdgeIo | typeof window): FetchJson {
-  return function fetchJson(uri, opts) {
-    return io.fetch(uri, opts).then(reply => {
-      if (!reply.ok) {
-        throw new Error(`Error ${reply.status} while fetching ${uri}`)
-      }
-      return reply.json()
-    })
-  }
-}
-
-export function makeFetchText(io: EdgeIo | typeof window): FetchText {
-  return function fetchText(uri, opts) {
-    return io.fetch(uri, opts).then(reply => {
-      if (!reply.ok) {
-        throw new Error(`Error ${reply.status} while fetching ${uri}`)
-      }
-      return reply.text()
-    })
-  }
-}
-
 /**
  * The extra things we need to add to the EdgeIo object.
  */
 export type ExtraIo = {
-  +fetchJson: FetchJson,
-  +fetchText: FetchText,
   +secp256k1?: EdgeSecp256k1,
   +pbkdf2?: EdgePbkdf2,
   makeSocket(opts: EdgeSocketOptions): Promise<EdgeSocket>

--- a/src/react-native-io.js
+++ b/src/react-native-io.js
@@ -10,9 +10,7 @@ import {
   type EdgeSocket,
   type EdgeSocketOptions,
   type ExtraIo,
-  makeEdgeSocket,
-  makeFetchJson,
-  makeFetchText
+  makeEdgeSocket
 } from './plugin/pluginIo.js'
 
 export default function makeCustomIo(): ExtraIo {
@@ -20,8 +18,6 @@ export default function makeCustomIo(): ExtraIo {
   bridgifyObject(secp256k1)
 
   return {
-    fetchJson: makeFetchJson(window),
-    fetchText: makeFetchText(window),
     pbkdf2,
     secp256k1,
     makeSocket(opts: EdgeSocketOptions): Promise<EdgeSocket> {

--- a/test/engine/currencyEngine/currencyEngine.js
+++ b/test/engine/currencyEngine/currencyEngine.js
@@ -28,6 +28,7 @@ const fakeLogger = {
   warn: () => {},
   error: () => {}
 }
+const log = Object.assign(() => {}, { error() {}, warn() {} })
 
 const DATA_STORE_FOLDER = 'txEngineFolderBTC'
 const FIXTURES_FOLDER = join(__dirname, 'fixtures')
@@ -64,13 +65,14 @@ for (const dir of dirs(FIXTURES_FOLDER)) {
 
   const fakeIo = makeFakeIo()
   const pluginOpts: EdgeCorePluginOptions = {
+    initOptions: {},
     io: {
       ...fakeIo,
       console: fakeLogger,
       random: size => fixture.key,
       fetch: fetch
     },
-    initOptions: {},
+    log,
     nativeIo: {},
     pluginDisklet: fakeIo.disklet
   }
@@ -104,6 +106,7 @@ for (const dir of dirs(FIXTURES_FOLDER)) {
   const walletLocalFolder = downgradeDisklet(walletLocalDisklet)
   const engineOpts: EdgeCurrencyEngineOptions = {
     callbacks,
+    log,
     walletLocalDisklet,
     walletLocalEncryptedDisklet: walletLocalDisklet,
     userSettings: fixture.ChangeSettings

--- a/test/plugin/currencyPlugin/currencyPlugin.js
+++ b/test/plugin/currencyPlugin/currencyPlugin.js
@@ -18,6 +18,7 @@ const fakeLogger = {
   warn: () => {},
   error: () => {}
 }
+const log = Object.assign(() => {}, { error() {}, warn() {} })
 
 for (const fixture of fixtures) {
   const WALLET_TYPE = fixture.WALLET_TYPE
@@ -30,12 +31,13 @@ for (const fixture of fixtures) {
 
   const fakeIo = makeFakeIo()
   const pluginOpts: EdgeCorePluginOptions = {
+    initOptions: {},
     io: {
       ...fakeIo,
       console: fakeLogger,
       random: size => fixture.key
     },
-    initOptions: {},
+    log,
     nativeIo: {},
     pluginDisklet: fakeIo.disklet
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2266,10 +2266,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-edge-core-js@0.16.17:
-  version "0.16.17"
-  resolved "https://registry.yarnpkg.com/edge-core-js/-/edge-core-js-0.16.17.tgz#88f086f6c574c2aa2396032d9532caf388c14696"
-  integrity sha512-knQje90Lnqs+fK5uKe494HkFoH0/vn4e+rASXcTEis3U6hLiPVRJh8/LLHUKlpF58YzIR8OJ6xJLLUiGILXB5A==
+edge-core-js@0.16.20:
+  version "0.16.20"
+  resolved "https://registry.yarnpkg.com/edge-core-js/-/edge-core-js-0.16.20.tgz#a109fe87d71cf112f888810b008d2431c470f1f0"
+  integrity sha512-q7yMY/285ZYavmDQ486R39VXYk3stHudzjxzA4Nzbz5ZP9xt1BWzVnR0jG/kR6Eb2tMQzYsi2YYSUiuZwyvCsQ==
   dependencies:
     aes-js "^3.1.0"
     base-x "^1.0.4"
@@ -2289,9 +2289,8 @@ edge-core-js@0.16.17:
     redux-pixies "^0.3.6"
     rfc4648 "^1.1.0"
     scrypt-js "^2.0.3"
-    utf8 "^3.0.0"
     ws "^5.1.1"
-    yaob "^0.3.5"
+    yaob "^0.3.6"
 
 electron-to-chromium@^1.3.322:
   version "1.3.322"
@@ -6983,11 +6982,6 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-utf8@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
-  integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
-
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -7250,10 +7244,10 @@ yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yaob@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/yaob/-/yaob-0.3.5.tgz#838035a8488a2b0f1b6117db171730bdcb57a75a"
-  integrity sha512-b2r4f4r+nDZKLfDCYHCubQNe/V7SLlzLrfufYwik9FC5yiSlzTc074wQpo1Q418fhiJvfUMP74HubOEkVWgZTA==
+yaob@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/yaob/-/yaob-0.3.6.tgz#84f9970d2e3629e041a791d1dea41f8a5387e91f"
+  integrity sha512-MGfSGsmQsRgWM62vPn+7NjSeU70EH78aZg5uXhLGAw94C7nMDxKJaamozTTGuiF4cwp8bsoM4cOhiDogk23INg==
   dependencies:
     rfc4648 "^1.1.0"
 


### PR DESCRIPTION
This pulls in the latest Flow types from the core, and gets us using the new `fetchCors` method.

I tried but failed to use the new logging methods - this library wrongly sets up a global `logger` file, so there is no way to get the logs separated by plugin & engine without removing that. It's not hard to do, just a lot of work.