### PR TITLE
Fix InsufficientFundsError type in makeSpend method

### DIFF
--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -624,7 +624,7 @@ export class CurrencyEngine {
       }
       return edgeTransaction
     } catch (e) {
-      if (e.type === 'FundingError') throw new Error('InsufficientFundsError')
+      if (e.type === 'FundingError') throw new InsufficientFundsError()
       throw e
     }
   }

--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -564,7 +564,7 @@ export class CurrencyEngine {
     const { utxos = this.engineState.getUTXOs() } = txOptions
     // Test if we have enough to spend
     if (bns.gt(totalAmountToSend, `${sumUtxos(utxos)}`)) {
-      throw new InsufficientFundsError()
+      throw new InsufficientFundsError(this.currencyCode)
     }
     try {
       // Get the rate according to the latest fee
@@ -624,7 +624,7 @@ export class CurrencyEngine {
       }
       return edgeTransaction
     } catch (e) {
-      if (e.type === 'FundingError') throw new InsufficientFundsError()
+      if (e.type === 'FundingError') throw new InsufficientFundsError(this.currencyCode)
       throw e
     }
   }


### PR DESCRIPTION
Currently errors in the `CurrencyEngine.makeSpend` are not consistent. It's very difficult to properly handle InsufficientFundsError as it's thrown as a plain JS Error under circumstances when `FundingError` occurs.

This MR fixes incorrect error type in `makeSpend` method.