### PR TITLE
Upgrade to the new info server URL

### DIFF
--- a/src/info/badcoin.js
+++ b/src/info/badcoin.js
@@ -30,7 +30,6 @@ const engineInfo: EngineCurrencyInfo = {
   gapLimit: 10,
   defaultFee: 500000,
   feeUpdateInterval: 60000,
-  infoServer: 'https://info1.edgesecure.co:8444/v1',
   customFeeSettings: ['satPerByte'],
   simpleFeeSettings: {
     highFee: '300',

--- a/src/info/constants.js
+++ b/src/info/constants.js
@@ -1,7 +1,7 @@
 // @flow
 
 export const imageServerUrl = 'https://developer.airbitz.co/content'
-export const InfoServer = 'https://info1.edgesecure.co:8444/v1'
+export const InfoServer = 'https://info1.edge.app/v1'
 
 export const FixCurrencyCode = (currencyCode: string): string => {
   switch (currencyCode) {

--- a/src/info/eboost.js
+++ b/src/info/eboost.js
@@ -30,7 +30,6 @@ const engineInfo: EngineCurrencyInfo = {
   gapLimit: 10,
   defaultFee: 500000,
   feeUpdateInterval: 60000,
-  infoServer: 'https://info1.edgesecure.co:8444/v1',
   customFeeSettings: ['satPerByte'],
   simpleFeeSettings: {
     highFee: '300',


### PR DESCRIPTION
Now that the info server uses Caddy, we can drop the weird port.

Also, it turns out that the engine info no longer has an `infoServer` property since https://github.com/EdgeApp/edge-currency-bitcoin/commit/4064fac53293c99d08438c4502f70bd992bb3f81, so we can just drop those.