### PR TITLE
Handle Anypay multi-coin payment codes [REFERENCE ONLY DO NOT MERGE]

### DIFF
--- a/src/engine/paymentRequest.js
+++ b/src/engine/paymentRequest.js
@@ -29,9 +29,13 @@ const getSpendTargets = (
 const getBitPayPayment = async (
   paymentProtocolURL: string,
   network: string,
+  currencyCode: string,
   fetch: any
 ): Promise<EdgePaymentProtocolInfo> => {
-  const headers = { Accept: 'application/payment-request' }
+  const headers = {
+    Accept: 'application/payment-request',
+    'x-currency': currencyCode
+  }
   const result = await fetch(paymentProtocolURL, { headers })
   if (parseInt(result.status) !== 200) {
     const error = await result.text()
@@ -78,7 +82,7 @@ export async function getPaymentDetails(
   currencyCode: string,
   fetch: any
 ): Promise<EdgePaymentProtocolInfo> {
-  return getBitPayPayment(paymentProtocolURL, network, fetch)
+  return getBitPayPayment(paymentProtocolURL, network, currencyCode, fetch)
 }
 
 export function createPayment(

--- a/src/utils/coinUtils.js
+++ b/src/utils/coinUtils.js
@@ -144,6 +144,7 @@ export const verifyUriProtocol = (
   const { uriPrefix = '' } = networks[network] || {}
   if (protocol) {
     const prot = protocol.replace(':', '').toLowerCase()
+    if (prot === 'pay') { return true }
     return prot === pluginName || prot === uriPrefix
   }
   return true


### PR DESCRIPTION
The Anypay protocol adds two tiny extensions to the BitPay JSON protocol:

1) QR codes start with `pay:` instead of `bitcoin:`, `bitcoincash:`, or `bitcoinsv:`
2) `x-currency` header specifies which coin Edge wallet wants to use as payment

Although this update is nearly trivial I have not yet performed integrated testing within the wallet app.