### PR TITLE
Specify Header X-Currency To Indicate Coin In JSON V2 Pay Protocol

### DIFF
--- a/src/engine/paymentRequest.js
+++ b/src/engine/paymentRequest.js
@@ -29,9 +29,13 @@ const getSpendTargets = (
 const getBitPayPayment = async (
   paymentProtocolURL: string,
   network: string,
+  currencyCode: string,
   fetch: any
 ): Promise<EdgePaymentProtocolInfo> => {
-  const headers = { Accept: 'application/payment-request' }
+  const headers = {
+    Accept: 'application/payment-request',
+    'x-currency': currencyCode
+  }
   const result = await fetch(paymentProtocolURL, { headers })
   if (parseInt(result.status) !== 200) {
     const error = await result.text()
@@ -78,7 +82,7 @@ export async function getPaymentDetails(
   currencyCode: string,
   fetch: any
 ): Promise<EdgePaymentProtocolInfo> {
-  return getBitPayPayment(paymentProtocolURL, network, fetch)
+  return getBitPayPayment(paymentProtocolURL, network, currencyCode, fetch)
 }
 
 export function createPayment(


### PR DESCRIPTION
Enables Anypay servers to know for which coin to provide a payment request, since Anypay handles all coins at a single URL.

Customers can pay with BTC, BCH, or BSV without needing to tell the cashier which are going to use.

Here you may watch of me demonstrating with explanation the user experience benefits of the this pull request:

https://anypayinc.s3.amazonaws.com/videos/telegram-cloud-document-1-5012867969970077867.mp4