### PR TITLE
Add hardFee to fix Dogecoin fees to 1 DOGE

### DIFF
--- a/src/info/dogecoin.js
+++ b/src/info/dogecoin.js
@@ -39,6 +39,7 @@ const engineInfo: EngineCurrencyInfo = {
     standardFeeLowAmount: '2000000000',
     standardFeeHighAmount: '98100000000'
   },
+  hardFee: 100000000,
   timestampFromHeader(header: Buffer): number {
     if (header.length < 80) {
       throw new Error(`Cannot interpret block header ${header.toString('hex')}`)

--- a/src/utils/coinUtils.js
+++ b/src/utils/coinUtils.js
@@ -66,6 +66,7 @@ export type CreateTxOptions = {
   outputs?: Array<StandardOutput>,
   height?: BlockHeight,
   estimate?: Function,
+  hardFee?: number,
   txOptions: TxOptions
 }
 
@@ -189,6 +190,7 @@ export const createTX = async ({
   height = -1,
   estimate,
   network,
+  hardFee,
   txOptions: {
     selection = 'value',
     RBFraw = '',
@@ -261,7 +263,8 @@ export const createTX = async ({
     subtractFee,
     height,
     rate,
-    estimate
+    estimate,
+    hardFee
   })
 
   // If TX is RBF mark is by changing the Inputs sequences

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,7 +1263,7 @@ base@^0.11.1:
 
 "bcoin@git+https://github.com/Airbitz/bcoin.git#primitiveBuild":
   version "1.0.0-beta.15"
-  resolved "git+https://github.com/Airbitz/bcoin.git#e1e5d9836d07ddae03fb31838dbea2118a15d4c7"
+  resolved "git+https://github.com/Airbitz/bcoin.git#cf7b7d63a0ed2b0c468672b01cdbdc511272aec7"
   dependencies:
     bn.js "4.11.8"
     elliptic "6.4.0"


### PR DESCRIPTION
Update to newer version of bcoin that removes MAX_FEE on rate and hardFee. This limit was no longer necessary since GUI shows fee warning modal for high fee.