### PR TITLE
Bump bitpay fees

### DIFF
--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -374,7 +374,7 @@ export class CurrencyEngine {
     ) {
       const requiredFeeRate =
         otherParams.paymentProtocolInfo.merchant.requiredFeeRate
-      return Math.ceil(parseFloat(requiredFeeRate) * BYTES_TO_KB * 1.5)
+      return Math.ceil(parseFloat(requiredFeeRate) * BYTES_TO_KB * 1.75)
     }
     const customFeeSetting = this.engineInfo.customFeeSettings[0]
     const customFeeAmount = customNetworkFee[customFeeSetting] || '0'


### PR DESCRIPTION
Bitpay doesn't seem to calculate the segwit discount so we need to bump the fees so transactions with many inputs have a larger chance of success. Similar to https://github.com/EdgeApp/edge-currency-bitcoin/commit/7d98f6360dc99d89147fd1637cd2ca7eeb5f4ee1

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201818782291351