### PR TITLE
Work around Android PBKDF2 failures

### DIFF
--- a/src/utils/bcoinExtender/patchCrypto.js
+++ b/src/utils/bcoinExtender/patchCrypto.js
@@ -1,3 +1,4 @@
+import { crypto } from 'bcoin'
 import { Buffer } from 'buffer'
 import { assert } from 'chai'
 import { nfkd } from 'unorm'
@@ -259,13 +260,24 @@ export const patchPbkdf2 = function (bcoin, pbkdf2) {
     const phrase = nfkd(mnemonic.getPhrase())
     const passwd = nfkd('mnemonic' + passphrase)
 
-    let derived = await pbkdf2.deriveAsync(
-      Buffer.from(phrase, 'utf8'),
-      Buffer.from(passwd, 'utf8'),
-      2048,
-      64,
-      'sha512'
-    )
+    let derived = await pbkdf2
+      .deriveAsync(
+        Buffer.from(phrase, 'utf8'),
+        Buffer.from(passwd, 'utf8'),
+        2048,
+        64,
+        'sha512'
+      )
+      .catch(() =>
+        crypto.pbkdf2.derive(
+          Buffer.from(phrase, 'utf8'),
+          Buffer.from(passwd, 'utf8'),
+          2048,
+          64,
+          'sha512'
+        )
+      )
+
     derived = Buffer.from(derived)
     return this.fromSeed(derived, network)
   }


### PR DESCRIPTION
Since the react-native-fast-crypto library isn't always working on older Androids, we can just fall back on JS if something goes wrong.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202119846830150